### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,8 @@ name: PR Checks
 
 on: pull_request
 
+permissions:
+  contents: read
 jobs:
   build:
     name: Run PR Checks

--- a/.github/workflows/deploy_lower.yml
+++ b/.github/workflows/deploy_lower.yml
@@ -9,6 +9,8 @@ env:
   ASTRO_DB_APP_TOKEN: ${{ secrets.ASTRO_DB_APP_TOKEN }}
   ASTRO_DB_REMOTE_URL: ${{ secrets.ASTRO_DB_REMOTE_URL }}
 
+permissions:
+  contents: read
 jobs:
   build:
     name: Build and Deploy to Cloudflare

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: Deploy Pages Site Prod
 
 on:
@@ -13,6 +11,8 @@ env:
   ASTRO_DB_APP_TOKEN: ${{ secrets.ASTRO_DB_APP_TOKEN }}
   ASTRO_DB_REMOTE_URL: ${{ secrets.ASTRO_DB_REMOTE_URL }}
 
+permissions:
+  contents: read
 jobs:
   build_stage:
     name: Build and Deploy to Cloudflare

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy Pages Site Prod
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/The-Veteran-Culture-Project/site/security/code-scanning/6](https://github.com/The-Veteran-Culture-Project/site/security/code-scanning/6)

To address the problem, explicitly define the minimal required `permissions` at either the workflow or job level. In this workflow, neither the `build_stage` nor `build_prod` jobs push or modify code or workflow artifacts in the repository; they perform deployment to Cloudflare and use secrets, and only appear to check out and build the code. Thus, the minimal required GitHub permission is `contents: read`, which allows jobs to clone or check out the repository code. 

The correct way to fix the problem is to add a top-level `permissions` block just below the workflow `name` and before the `on:` key. This applies to both jobs, as they both require only read access. If any job needed more (e.g. to create pull requests or issues), it could be set there instead, or overridden at the job level.

**Implementation details:**
- Add the following block after `name: Deploy Pages Site Prod`:
  ```yaml
  permissions:
    contents: read
  ```
- No changes are required for imports, methods, or definitions since this is a YAML workflow file.
- No additional packages or actions are required to be installed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
